### PR TITLE
Add ci support using Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: android
+
+android:
+  components:
+    - build-tools-18.1.1
+    - android-18
+    - extra-android-support
+    - extra-google-m2repository
+    - extra-android-m2repository
+
+before_install:
+    - cp -R $ANDROID_HOME/extras/android/m2repository/ ~/.m2/repository/
+
+install: mvn clean install
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Button Menu [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.tuenti.buttonmenu/library/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.tuenti.buttonmenu/library) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Button%20Menu-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/887)
+Button Menu [![Build Status](https://travis-ci.org/tuenti/ButtonMenu.svg?branch=master)](https://travis-ci.org/tuenti/ButtonMenu) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.tuenti.buttonmenu/library/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.tuenti.buttonmenu/library) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Button%20Menu-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/887)
 ===========
 
 ButtonMenu is an Android library created to build user interfaces based on buttons. This library has been implemented

--- a/pom.xml
+++ b/pom.xml
@@ -29,15 +29,16 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<junit.version>4.11</junit.version>
 		<android.version>4.1.1.4</android.version>
-		<robolectric.version>2.3</robolectric.version>
-		<renderers.version>1.1.1</renderers.version>
-		<picasso.version>2.1.1</picasso.version>
-		<circleimageview.version>1.1.1</circleimageview.version>
-		<library.version>2.4.0</library.version>
-		<mockito-all.version>1.9.5</mockito-all.version>
-	</properties>
+    <android-maven-plugin.version>3.9.0-rc.3</android-maven-plugin.version>
+    <junit.version>4.11</junit.version>
+    <robolectric.version>2.3</robolectric.version>
+    <renderers.version>1.1.1</renderers.version>
+    <picasso.version>2.1.1</picasso.version>
+    <circleimageview.version>1.1.1</circleimageview.version>
+    <library.version>2.4.0</library.version>
+    <mockito-all.version>1.9.5</mockito-all.version>
+  </properties>
 
 	<dependencyManagement>
 		<dependencies>
@@ -117,7 +118,7 @@
 				<plugin>
 					<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 					<artifactId>android-maven-plugin</artifactId>
-					<version>3.8.2</version>
+					<version>${android-maven-plugin.version}</version>
 					<configuration>
 						<sdk>
 							<platform>18</platform>


### PR DESCRIPTION
Hi Tuenti developers!

In this PR you are going to find this:
- A new .travis.yml file to add support to Travis-CI and be able to know if the build is working or not.
- A new badge in your README.md file pointing to your Travis-CI ButtonMenu project.
- One change related to the Android Maven plugin used in the project. This change is needed to be able to build the project in the Travis environment.

Here you have the build associated to this changeset https://travis-ci.org/pedrovgs/ButtonMenu/builds/64337860 :)

Please, review you've activated this project into your Travis dashboard.
